### PR TITLE
Fix django carton

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,21 @@
 
 
 
-### Square SDK Python Install
+### WARNING!!!
 
-"You must use the following repo to properly install square"
+The django-carton package is out of date. To deal with that I forked the
+github repo into https://github.com/Daniel-Avila/django-carton.git.
 
-``$: pip install git+https://github.com/square/connect-python-sdk.git
-``
+You will need to remove the current django-carton install and rerun
 
+`pip install -r requirments.txt`
 
+To install the corrected version of django-carton.
+
+I put in a pull request from our fork to the connonical project in the event
+they want to update it.
+
+#### NOTE: Disregard the following. It is being left for reference.
 'In site-packages under the carton modules template tag folder
 you must replace line 25 to:'
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@
 The django-carton package is out of date. To deal with that I forked the
 github repo into https://github.com/Daniel-Avila/django-carton.git.
 
-You will need to remove the current django-carton install and rerun
+You will need to remove the current django-carton install
+
+ `pip uninstal django-carton`
+
+ and rerun
 
 `pip install -r requirments.txt`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ channels==2.1.1
 constantly==15.1.0
 daphne==2.1.1
 Django==2.0.4
-django-carton==1.2.1
 django-crispy-forms==1.7.2
 django-registration-redux==2.4
 html5lib==1.0.1
@@ -26,3 +25,4 @@ urllib3==1.22
 webencodings==0.5.1
 zope.interface==4.5.0
 git+https://github.com/square/connect-python-sdk.git
+git+https://github.com/Daniel-Avila/django-carton.git


### PR DESCRIPTION
Fixed django-carton by forking the main repo. This way we do not have to manually hack code. 